### PR TITLE
Set up vitest and add regionStore test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@aws-amplify/ui-vue": "^4.3.3",
@@ -31,6 +32,7 @@
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
-    "vue-tsc": "^2.2.8"
+    "vue-tsc": "^2.2.8",
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/regionStore.spec.ts
+++ b/tests/regionStore.spec.ts
@@ -1,0 +1,48 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { useRegionStore } from '../src/stores/regionStore';
+import type { Region } from '../src/module_bindings/client';
+
+function makeRegion(id: string, links: string[] = []): Region {
+  return {
+    regionId: id,
+    name: `Region ${id}`,
+    description: '',
+    fullDescription: '',
+    climate: '',
+    culture: '',
+    travelEnergyCost: 0,
+    tier: 0,
+    isStarterRegion: false,
+    linkedRegionIds: links,
+    resources: [],
+  };
+}
+
+describe('findConnectedRegions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('returns regions connected to given id', () => {
+    const store = useRegionStore();
+    const a = makeRegion('A', ['B']);
+    const b = makeRegion('B', ['A', 'C']);
+    const c = makeRegion('C', ['B']);
+    store.regions.value = new Map([
+      [a.regionId, a],
+      [b.regionId, b],
+      [c.regionId, c],
+    ]);
+
+    const connectedToB = store.findConnectedRegions('B');
+    expect(connectedToB).toHaveLength(2);
+    expect(connectedToB).toContain(a);
+    expect(connectedToB).toContain(c);
+  });
+
+  it('returns empty array when no regions link to id', () => {
+    const store = useRegionStore();
+    store.regions.value = new Map();
+    expect(store.findConnectedRegions('X')).toStrictEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add vitest configuration and npm test script
- create `regionStore.spec.ts` with Pinia store tests

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad5dd69848332a2ee0cd8010f5f53