### PR TITLE
Fix duplicate quests on update

### DIFF
--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -83,8 +83,24 @@ export const useCharacterStore = defineStore('characterStore', () => {
       console.warn('No active SpaceTimeDB connection');
       return;
     }
-    
-    connection.value.reducers.updateCharacter(character);
+
+    const payload: UpdateCharacterInput = { ...character };
+
+    if (payload.quests && currentCharacter.value?.quests) {
+      const existingIds = new Set(
+        currentCharacter.value.quests.map((q) => q.questId)
+      );
+      const filtered = payload.quests.filter((q) => !existingIds.has(q.questId));
+
+      if (filtered.length > 0) {
+        payload.quests = filtered;
+      } else {
+        // prevent sending empty quest array
+        delete (payload as any).quests;
+      }
+    }
+
+    connection.value.reducers.updateCharacter(payload);
   }
 
   function setCurrentCharacter(character: Character | null) 


### PR DESCRIPTION
## Summary
- avoid duplicate quests in front-end updateCharacter
- revert server module formatting/comment changes

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adac6e9d883329bde4cca3f6ca0ba